### PR TITLE
Feature #23745 Extend Monitor to Support Services Monitoring

### DIFF
--- a/src/rb_sensor_monitor.c
+++ b/src/rb_sensor_monitor.c
@@ -361,6 +361,13 @@ static rb_monitor_t *parse_rb_monitor0(enum monitor_cmd_type type,
 		goto err;
 	}
 
+  json_object *monitor_enrichment = NULL;
+  if (json_object_object_get_ex(json_monitor, "enrichment", &monitor_enrichment)) {
+    json_object_object_foreach(monitor_enrichment, key, val) {
+      json_object_object_add(ret->enrichment, key, json_object_get(val));
+    }
+  }
+
 #define RB_MONITOR_ENRICHMENT_STR(mkey, mval)                                  \
 	{                                                                      \
 		.key = mval ? mkey : NULL,                                     \


### PR DESCRIPTION
## Redmine task

[https://redmine.redborder.lan/issues/23745](https://redmine.redborder.lan/issues/23745)

## Changes

Now the monitors of a sensor are able to have its own enrichment.